### PR TITLE
Error needs to be an out parameter, otherwise it can never be read.

### DIFF
--- a/ZipArchive/Main.h
+++ b/ZipArchive/Main.h
@@ -28,13 +28,13 @@
           toDestination:(NSString *)destination
               overwrite:(BOOL)overwrite
                password:(NSString *)password
-                  error:(NSError *)error;
+                  error:(NSError * __autoreleasing *)error;
 
 + (BOOL)unzipFileAtPath:(NSString *)path
           toDestination:(NSString *)destination
               overwrite:(BOOL)overwrite
                password:(NSString *)password
-                  error:(NSError *)error
+                  error:(NSError * __autoreleasing *)error
                delegate:(id<ZipArchiveDelegate>)delegate;
 
 + (BOOL)unzipFileAtPath:(NSString *)path
@@ -46,7 +46,7 @@
           toDestination:(NSString *)destination
               overwrite:(BOOL)overwrite
                password:(NSString *)password
-                  error:(NSError *)error
+                  error:(NSError * __autoreleasing *)error
                delegate:(id<ZipArchiveDelegate>)delegate
         progressHandler:(void (^)(NSString *entry, unz_file_info zipInfo, long entryNumber, long total))progressHandler
       completionHandler:(void (^)(NSString *path, BOOL succeeded, NSError *error))completionHandler;

--- a/ZipArchive/Main.m
+++ b/ZipArchive/Main.m
@@ -40,7 +40,7 @@
           toDestination:(NSString *)destination
               overwrite:(BOOL)overwrite
                password:(NSString *)password
-                  error:(NSError *)error {
+                  error:(NSError * __autoreleasing *)error {
     
     return [self unzipFileAtPath:path
                    toDestination:destination
@@ -70,7 +70,7 @@
           toDestination:(NSString *)destination
               overwrite:(BOOL)overwrite
                password:(NSString *)password
-                  error:(NSError *)error
+                  error:(NSError * __autoreleasing *)error
                delegate:(id<ZipArchiveDelegate>)delegate {
     
     return [self unzipFileAtPath:path
@@ -119,7 +119,7 @@
           toDestination:(NSString *)destination
               overwrite:(BOOL)overwrite
                password:(NSString *)password
-                  error:(NSError *)error
+                  error:(NSError * __autoreleasing *)error
                delegate:(id<ZipArchiveDelegate>)delegate
         progressHandler:(void (^)(NSString *entry, unz_file_info zipInfo, long entryNumber, long total))progressHandler
       completionHandler:(void (^)(NSString *path, BOOL succeeded, NSError *error))completionHandler {
@@ -132,7 +132,7 @@
         NSError *err = [NSError errorWithDomain:@"ZipArchiveErrorDomain" code:-1 userInfo:userInformation];
         
         if (error) {
-            error = err;
+            *error = err;
         }
         
         if (completionHandler) {
@@ -156,7 +156,7 @@
         NSError *err = [NSError errorWithDomain:@"ZipArchiveErrorDomain" code:-2 userInfo:userInformation];
         
         if (error) {
-            error = err;
+            *error = err;
         }
         
         if (completionHandler) {

--- a/ZipArchiveTests/ZipArchiveTests.m
+++ b/ZipArchiveTests/ZipArchiveTests.m
@@ -169,7 +169,7 @@
             toDestination:outputPath
                 overwrite:YES
                  password:@"passw0rd"
-                    error:error
+                    error:&error
                  delegate:self];
     
     NSFileManager *fileManager = [NSFileManager defaultManager];


### PR DESCRIPTION
#### Summary

The received error pointer is re-assigned but can never be read. This addresses the dead store warnings that the analyser finds.
