### PR TITLE
Fixed new warning in Xcode 7.

### DIFF
--- a/ZipArchive/Main.h
+++ b/ZipArchive/Main.h
@@ -64,6 +64,8 @@
 
 - (instancetype)initWithPath:(NSString *)path NS_DESIGNATED_INITIALIZER;
 
+- (instancetype)init __attribute__((unavailable("-init is unavailable; use -initWithPath")));
+
 @property (NS_NONATOMIC_IOSONLY, readonly) BOOL open;
 @property (NS_NONATOMIC_IOSONLY, readonly) BOOL close;
 


### PR DESCRIPTION
"Method override for the designated initializer of the superclass '-init' not found"
